### PR TITLE
Fix Read More sometimes having broken html

### DIFF
--- a/_includes/read-more.html
+++ b/_includes/read-more.html
@@ -5,7 +5,9 @@
     </div><!-- /.read-more-header -->
     <div class="read-more-content">
       <h3><a href="{{ site.url }}{{ post.url }}" title="{{ post.title }}">{{ post.title }}</a></h3>
-      <p>{% if post.description %}{{ post.description }}{% else %}{{ post.content | markdownify | strip_newlines | truncate: 140 }}&hellip;{% endif %} <a href="{{ site.url }}{{ post.url }}">Continue reading</a></p>
+      <p>
+        {% if post.description %}{{ post.description }}{% else if post.excerpt %}{{ post.excerpt }}{% else %}{{ post.content | strip_html | truncate: 140 }}{% endif %}<a href="{{ site.url }}{{ post.url }}">Read More</a>
+      </p>
     </div><!-- /.read-more-content -->
   {% endfor %}
   <div class="read-more-list">


### PR DESCRIPTION
The Read More section below a post would truncate after 140 characters
before. Including code. That could make truncate in the middle of an
html element, rendering a broken page.

This patch tries to improve the situation by using the excerpt when
available (like the start page), and falls back on truncate content
that's been stripped from html.
